### PR TITLE
Add a `WORKSPACE.bazel` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Bazel output symlinks.
+/bazel-*

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,9 @@
+workspace(name = "com_github_3rdparty_bazel_rules_jemalloc")
+
+load("//bazel:repos.bzl", "repos")
+
+repos(external = False)
+
+load("//bazel:deps.bzl", "deps")
+
+deps()

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -22,11 +22,14 @@ def repos(external = True, repo_mapping = {}):
         repo_mapping = repo_mapping,
     )
 
-    maybe(
-        http_archive,
-        name = "com_github_3rdparty_bazel_rules_jemalloc",
-        url = "https://github.com/3rdparty/bazel-rules-jemalloc/archive/5.2.1.tar.gz",
-        sha256 = "ed51b0b37098af4ca6ed31c22324635263f8ad6471889e0592a9c0dba9136aea",
-        strip_prefix = "bazel-rules-jemalloc-jemalloc-5.2.1",
-        repo_mapping = repo_mapping,
-    )
+    if external:
+        maybe(
+            http_archive,
+            name = "com_github_3rdparty_bazel_rules_jemalloc",
+            # TODO(xander): Is this correct? This file doesn't exist, and
+            # bazel-rules-jemalloc has no published releases.
+            url = "https://github.com/3rdparty/bazel-rules-jemalloc/archive/5.2.1.tar.gz",
+            sha256 = "ed51b0b37098af4ca6ed31c22324635263f8ad6471889e0592a9c0dba9136aea",
+            strip_prefix = "bazel-rules-jemalloc-jemalloc-5.2.1",
+            repo_mapping = repo_mapping,
+        )


### PR DESCRIPTION
This makes `bazel` commands work in the root of this repo. It's also
necessary when using this repo as a git submodule of another repo.

Fix `repos.bzl` to avoid needlessly redefining this repo.

Errors this fixes when trying to use this repo as a submodule:
```
ERROR: /workspaces/respect/submodules/eventuals/WORKSPACE.bazel:7:21: fetching local_repository rule //external:com_github_3rdparty_bazel_rules_jemalloc: java.io.IOException: No WORKSPACE file found in /home/vscode/.cache/bazel/_bazel_vscode/08c0069c780f6342645a87341bf9a372/external/com_github_3rdparty_bazel_rules_jemalloc
ERROR: no such package '@com_github_3rdparty_bazel_rules_jemalloc//bazel': No WORKSPACE file found in /home/vscode/.cache/bazel/_bazel_vscode/08c0069c780f6342645a87341bf9a372/external/com_github_3rdparty_bazel_rules_jemalloc
```

This makes it easier to work in build errors like
https://github.com/3rdparty/eventuals/issues/470.

Note that bazel builds work, but the builds fail. Instead of:
```sh
$ bazel build //...
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a WORKSPACE file).
ERROR: The 'build' command is only supported from within a workspace (below a directory having a WORKSPACE file).
See documentation at https://docs.bazel.build/versions/main/build-ref.html#workspace
```

we now get path-too-long errors caused by what looks like a recursive
self-dependency:
```
$ bazel build //:jemalloc
INFO: Analyzed target //:jemalloc (44 packages loaded, 196 targets configured).
INFO: Found 1 target...
ERROR: /workspaces/respect/submodules/eventuals/submodules/bazel-rules-jemalloc/BUILD.bazel:18:23: Foreign Cc - Configure: Building jemalloc_preinstalled_make_ failed: (Exit 1): bash failed: error executing command /bin/bash -c bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/wrapper_build_script.sh

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
rules_foreign_cc: Build failed!
rules_foreign_cc: Keeping temp build directory and dependencies directory for debug.
rules_foreign_cc: Please note that the directories inside a sandbox are still cleaned unless you specify --sandbox_debug Bazel command line flag.
rules_foreign_cc: Printing build logs:
_____ BEGIN BUILD LOGS _____

Bazel external C/C++ Rules. Building library jemalloc_preinstalled_make_

Environment:______________
BUILD_SCRIPT=bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/build_script.sh
EXT_BUILD_ROOT=/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc
BUILD_LOG=bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/Configure.log
PWD=/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc
BUILD_WRAPPER_SCRIPT=bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/wrapper_build_script.sh
TMPDIR=/tmp
EXT_BUILD_DEPS=/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.ext_build_deps
BUILD_TMPDIR=/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir
SHLVL=2
INSTALLDIR=/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_
PATH=/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc:/home/vscode/.cache/bazelisk/downloads/bazelbuild/bazel-5.2.0-linux-x86_64/bin:/vscode/bin/linux-x64/b06ae3b2d2dbfe28bca3134cc6be65935cdfea6a/bin/remote-cli:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/python/bin:/home/vscode/.local/bin:/usr/local/py-utils/bin
_=/usr/bin/env
__________________________
cp: cannot stat '/home/vscode/.cache/bazel/_bazel_vscode/9ca7ff8bef1f72b856235e64b441ffe7/sandbox/linux-sandbox/2/execroot/com_github_3rdparty_bazel_rules_jemalloc/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make_.build_tmpdir/bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/build_script.sh': File name too long
_____ END BUILD LOGS _____
rules_foreign_cc: Build wrapper script location: bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build script location: bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/build_script.sh
rules_foreign_cc: Build log location: bazel-out/k8-fastbuild-ST-dd44be474a39/bin/jemalloc_preinstalled_make__foreign_cc/Configure.log

Target //:jemalloc_preinstalled_make failed to build
```

Even with these local build failures, other repos that include this
repo as a submodule build successfully after this PR.

Add a `.gitignore` file to ignore bazel outputs.