### PR TITLE
Fix using `jemalloc` in dynamic targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,11 +26,11 @@ configure_make_variant(
         "//conditions:default": {},
     }),
     lib_source = ":all",
-    out_static_libs = select({
+    out_shared_libs = select({
         "@bazel_tools//src/conditions:windows": [
-            "libjemalloc_a.lib",
+            "libjemalloc_so.lib",
         ],
-        "//conditions:default": ["libjemalloc.a"],
+        "//conditions:default": ["libjemalloc.so"],
     }),
     # We need to use the system-default make; the version of make packaged
     # with `rules_foreign_cc` (4.3) segfaults on GitHub's Actions workers.


### PR DESCRIPTION
Progress towards https://github.com/3rdparty/eventuals/issues/470 where
eventuals can't be build in a shared library.

TESTED=Ran the following command in
https://github.com/3rdparty/eventuals/tree/xander.jemalloc-shared-build-fix :
```
echo "building default" \
    && bazel build //test:sample-eventuals-grpc-binary-default-link \
    && echo "building static" \
    && bazel build //test:sample-eventuals-grpc-binary-static-link \
    && echo "building shared" \
    && bazel build //test:sample-eventuals-grpc-binary-shared-link \
    && echo "built all modes!"
```